### PR TITLE
Messages should be positioned at the top

### DIFF
--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -139,6 +139,7 @@ export default class MessageContainer extends React.Component {
     return (
       <View ref='container' style={{flex:1}}>
         <ListView
+          contentContainerStyle={{ flexGrow: 1, justifyContent: 'flex-end' }}
           enableEmptySections={true}
           keyboardShouldPersistTaps={true}
           automaticallyAdjustContentInsets={false}


### PR DESCRIPTION
This PR implements a fix suggested in: https://github.com/exponentjs/react-native-invertible-scroll-view/issues/11

Closes https://github.com/FaridSafi/react-native-gifted-chat/issues/181

Confirmed to be working on both short and long lists (previous PR used `flex` and not `flexGrow`)